### PR TITLE
Remove top-level .dir-locals.el

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,1 +1,0 @@
-((coq-mode . ((coq-prog-args . ("-emacs-U" "-I" "./ln/tlc")))))


### PR DESCRIPTION
Since various scripts at various relative directory depth require the
./ln/tlc library, it is not robust to add it just to the top-level as a
relative path. I just add it in the directories that need it, and we
don't need to check this in. Here is an example:
dot-calculus> cat dev/expansion/.dir-locals.el
((coq-mode . ((coq-prog-args . ("-emacs-U" "-I" "../../ln/tlc")))))
